### PR TITLE
update schema introspection

### DIFF
--- a/examples/commit-reveal/src/models.cairo
+++ b/examples/commit-reveal/src/models.cairo
@@ -94,7 +94,7 @@ impl ChoiceSchemaIntrospectionImpl of SchemaIntrospection<Choice> {
 
     #[inline(always)]
     fn layout(ref layout: Array<u8>) {
-        SchemaIntrospection::<felt252>::layout(ref layout);
+        layout.append(251);
     }
 
     #[inline(always)]


### PR DESCRIPTION
- `SchemaIntrospection::<felt252>::layout(ref layout)` can no longer be used due to https://github.com/dojoengine/dojo/pull/994